### PR TITLE
Move the Obsidian link inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Obsidian API
 
-Definitions for the latest Obsidian API (https://obsidian.md).
+Definitions for the latest [Obsidian](https://obsidian.md) API.
 
 **Warning:** The Obsidian API is still in early alpha and is subject to change at any time!
 


### PR DESCRIPTION
Makes it clear that it's a link a page about Obsidian, rather than a link to a file named `obsidian.md`