### PR TITLE
 moment <=2.29.1 has security vulnerability use >=2.29.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
         "@codemirror/state": "^0.19.6",
         "@codemirror/view": "^0.19.31",
         "@types/codemirror": "0.0.108",
-        "moment": "2.29.1"
+        "moment": "2.29.2"
     }
 }


### PR DESCRIPTION
moment <=2.29.1 has security vulnerability use >=2.29.2
see
https://snyk.io/vuln/SNYK-JS-MOMENT-2440688
and issue #55 
will need tests to be run, shouldn’t break as minor revision.