### PR TITLE
Issue #70 - Updated to moment@2.29.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
         "@codemirror/state": "^0.19.6",
         "@codemirror/view": "^0.19.31",
         "@types/codemirror": "0.0.108",
-        "moment": "2.29.2"
+        "moment": "2.29.3"
     }
 }


### PR DESCRIPTION
Updated  package.json  moment@2.29.1 -> 2.29.3 for vulnerability CVE-2022-24785 as mentioned in issue #70 
I haven't tested I presume it will be in Obsidians private repository?