### PR TITLE
Bump the `moment` dependency from v2.29.3 to v2.29.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "types": "obsidian.d.ts",
     "dependencies": {
         "@types/codemirror": "0.0.108",
-        "moment": "2.29.3"
+        "moment": "2.29.4"
     },
     "peerDependencies": {
         "@codemirror/state": "^6.0.0",


### PR DESCRIPTION
This updates the `moment` dependency from v2.29.3 to v2.29.4.

This version update addresses a [CVE][1] published in the GitHub Advisory Database, where a regular expression used in moment can leave the door open to DDoS attacks. This is unlikely to affect the Obsidian use case, but using this vulnerable version triggers security warnings (for example from GitHub's Dependabot) and the upgrade should be harmless given that the DDoS fix is the only thing in the [changelog][2] for this version.

[1]: https://github.com/advisories/GHSA-wc69-rhjr-hc9g
[2]: https://github.com/moment/moment/blob/develop/CHANGELOG.md#2294