### PR TITLE
Introduce simple `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+yarn.lock
+node_modules


### PR DESCRIPTION
This adds a simple `.gitignore` file to the repository which stops you accidentally committing Node.JS dependency-related files - namely lockfiles for NPM (`package-lock.json`) and Yarn (`yarn.lock`) and cached dependencies (`node_modules/**/*`).