### PR TITLE
Better canvas type defs

### DIFF
--- a/canvas.d.ts
+++ b/canvas.d.ts
@@ -1,15 +1,19 @@
-// A color used to encode color data for nodes and edges
-// can be a number (like "1") representing one of the (currently 6) supported colors.
-// or can be a custom color using the hex format "#FFFFFFF".
+import { Join } from "ts-toolbelt/out/String/Join";
+
+/**
+ * A color used to encode color data for nodes and edges
+ * can be a number (like "1") representing one of the (currently 6) supported colors.
+ * or can be a custom color using the hex format "#FFFFFFF".
+ */
 export type CanvasColor = string;
 
-// The overall canvas file's JSON
+/** The overall canvas file's JSON */
 export interface CanvasData {
     nodes: AllCanvasNodeData[];
     edges: CanvasEdgeData[];
 }
 
-// A node
+/** A node */
 export interface CanvasNodeData {
     // The unique ID for this node
     id: string;
@@ -24,62 +28,62 @@ export interface CanvasNodeData {
 
 export type AllCanvasNodeData = CanvasFileData | CanvasTextData | CanvasLinkData | CanvasGroupData;
 
-// A node that is a file, where the file is located somewhere in the vault.
+/** A node that is a file, where the file is located somewhere in the vault. */
 export interface CanvasFileData extends CanvasNodeData {
     type: 'file';
     file: string;
-    // An optional subpath which links to a heading or a block. Always starts with a `#`.
-    subpath?: string;
+    /** An optional subpath which links to a heading or a block. Always starts with a `#`. */
+    subpath?: Join<['#', string]>;
 }
 
-// A node that is plaintext.
+/** A node that is plaintext. */
 export interface CanvasTextData extends CanvasNodeData {
     type: 'text';
     text: string;
 }
 
-// A node that is an external resource.
+/** A node that is an external resource. */
 export interface CanvasLinkData extends CanvasNodeData {
     type: 'link';
     url: string;
 }
 
-// The background image rendering style
+/** The background image rendering style  */
 export type BackgroundStyle = 'cover' | 'ratio' | 'repeat';
 
-// A node that represents a group.
+/** A node that represents a group. */
 export interface CanvasGroupData extends CanvasNodeData {
     type: 'group';
-    // Optional label to display on top of the group.
+    /** Optional label to display on top of the group. */
     label?: string;
-    // Optional background image, stores the path to the image file in the vault.
+    /** Optional background image, stores the path to the image file in the vault. */
     background?: string;
-    // Optional background image rendering style; defaults to 'cover'.
+    /** Optional background image rendering style; defaults to 'cover'. */
     backgroundStyle?: BackgroundStyle;
 }
 
-// The side of the node that a connection is connected to
+/** The side of the node that a connection is connected to  */
 export type NodeSide = 'top' | 'right' | 'bottom' | 'left';
 
-// What to display at the end of an edge
+/** What to display at the end of an edge */
 export type EdgeEnd = 'none' | 'arrow';
 
-// An edge
+/** An edge */
 export interface CanvasEdgeData {
-    // The unique ID for this edge
+    /** The unique ID for this edge */
     id: string;
-    // The node ID and side where this edge starts
-    fromNode: string;
+    /** The node ID and side where this edge starts */
+    fromNode: CanvasNodeData["id"];
     fromSide: NodeSide;
-    // The starting edge end; defaults to 'none'
+    /** The starting edge end; defaults to 'none' */
     fromEnd?: EdgeEnd;
-    // The node ID and side where this edge ends
-    toNode: string;
+    /** The node ID and side where this edge ends */
+    toNode: CanvasNodeData["id"];
     toSide: NodeSide;
-    // The ending edge end; defaults to 'arrow'
+    /** The ending edge end; defaults to 'arrow' */
     toEnd?: EdgeEnd;
-    // The color of this edge
+    /** The color of this edge */
     color?: CanvasColor;
-    // The text label of this edge, if available
+    /** The text label of this edge, if available */
     label?: string;
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
     "name": "obsidian",
     "version": "1.1.13",
     "description": "Type definitions for the latest Obsidian API (https://obsidian.md)",
-    "keywords": ["obsdmd"],
+    "keywords": [
+        "obsdmd"
+    ],
     "homepage": "https://obsidian.md",
     "repository": {
         "type": "git",
@@ -13,7 +15,8 @@
     "types": "obsidian.d.ts",
     "dependencies": {
         "@types/codemirror": "0.0.108",
-        "moment": "2.29.4"
+        "moment": "2.29.4",
+        "ts-toolbelt": "^9.6.0"
     },
     "peerDependencies": {
         "@codemirror/state": "^6.0.0",


### PR DESCRIPTION
Hello! I noticed some improvements that could be made to the new canvas type defs and thought I'd send them over.

---

The main change here is to convert the comments to JSDoc. This presents
no changes when reading the file, but when using an IDE to look at the
types we're presented with the comments as supplementary info in a
tooltip etc. Very useful!

As well as this, we pull in the Join type from ts-toolbelt, which allows
us to enforce the type of `CanvasFileData["subpath"]` so it complies
with the description of it in the comment.

Lastly, we derive some types in `CanvasEdgeData` instead of using
`string`, which encodes the intent as well as the type and makes it less
likely to break in the future.