### PR TITLE
Add 'files-menu' event to Workspace class.

### DIFF
--- a/obsidian.d.ts
+++ b/obsidian.d.ts
@@ -4423,6 +4423,12 @@ export class Workspace extends Events {
     on(name: 'file-menu', callback: (menu: Menu, file: TAbstractFile, source: string, leaf?: WorkspaceLeaf) => any, ctx?: any): EventRef;
 
     /**
+     * Triggered when the user opens the context menu on a selection of files.
+     * @public
+     */
+    on(name: 'files-menu', callback: (menu: Menu, file: TAbstractFile[], source: string, leaf?: WorkspaceLeaf) => any, ctx?: any): EventRef;
+
+    /**
      * Triggered when the user opens the context menu on an editor.
      * @public
      */


### PR DESCRIPTION
Added another On method for the Workspace class to account for the `files-menu` event.  I have tested this method with obsidian.d.ts in a local project and it worked without issue.  The `files-menu` event can run in the main.js file that's generated from ESBuild, but TypeScript throws an error without this new method.