### PR TITLE
feat(docs): :sparkles: add api-extractor config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 package-lock.json
 yarn.lock
 node_modules
+input/obsidian.api.json

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -1,0 +1,41 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"projectFolder": ".",
+	"mainEntryPointFilePath": "<projectFolder>/obsidian.d.ts",
+	"bundledPackages": [],
+	"newlineKind": "os",
+	"compiler": {
+		"overrideTsconfig": {}
+	},
+	"docModel": {
+		"enabled": true,
+		"apiJsonFilePath": "<projectFolder>/input/<unscopedPackageName>.api.json"
+	},
+	"apiReport": {
+		"enabled": false
+	},
+	"dtsRollup": {
+		"enabled": false
+	},
+	"tsdocMetadata": {
+		"enabled": false
+	},
+	"messages": {
+		"compilerMessageReporting": {
+			"default": {
+				"logLevel": "warning"
+			}
+		},
+		"extractorMessageReporting": {
+			"default": {
+				"logLevel": "warning"
+			}
+		},
+		"tsdocMessageReporting": {
+			"default": {
+				"logLevel": "warning"
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
This is for the api-extractor to generate the api docs. Please see the [obsidian-developer-docs](https://github.com/obsidianmd/obsidian-developer-docs) repo for more info.

Refer to https://github.com/obsidianmd/obsidian-developer-docs/pull/55 for more information.