### PR TITLE
Add missing await for debounce example.

### DIFF
--- a/obsidian.d.ts
+++ b/obsidian.d.ts
@@ -922,7 +922,7 @@ export interface DataWriteOptions {
  *     console.log(text);
  * }, 1000, true);
  * debounced("Hello world"); // this will not be printed
- * sleep(500);
+ * await sleep(500);
  * debounced("World, hello"); // this will be printed to the console.
  * ```
  * @public


### PR DESCRIPTION
This adds missing await for debounce function example.

The code works as described, but not as expected: the code will not pause because the sleep call itself does not pause execution, but returns a promise.