### PR TITLE
Fix tiny typo just introduced in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Type definitions for the latest [Obsidian](https://obsidian.md) API.
 
 You can browse our Plugin API documentation at https://docs.obsidian.md/
 
-For a example on how to create Obsidian plugins, use the template at https://github.com/obsidianmd/obsidian-sample-plugin 
+For an example on how to create Obsidian plugins, use the template at https://github.com/obsidianmd/obsidian-sample-plugin 
 
 ### Plugin structure
 


### PR DESCRIPTION
This small typo was introduced by deletion of a word in 390135d0ef5860703464467cfddc12fece8e613f.