### PR TITLE
fix: property 'file' doesn't exists on type 'View'

### DIFF
--- a/obsidian.d.ts
+++ b/obsidian.d.ts
@@ -4279,6 +4279,11 @@ export abstract class View extends Component {
      * @public
      */
     navigation: boolean;
+    /**
+     * The file associated with the view.
+     * @public
+     */
+    file: TFile | null
 
     /**
      * @public


### PR DESCRIPTION
When call code like this:
```typescript
const fileIsAlreadyOpen = workspace.getLeavesOfType('markdown').some((leaf) => leaf.view.file.path === path);
// It throws error: property 'file' doesnt't exists on type 'View'
```
This commit adds missed property.