### PR TITLE
add `null` to `Secret#onChange` callback argument type

### DIFF
--- a/obsidian.d.ts
+++ b/obsidian.d.ts
@@ -5453,7 +5453,7 @@ export class SecretComponent extends BaseComponent {
      * @public
      * @since 1.11.4
      */
-    onChange(cb: (value: string) => unknown): this;
+    onChange(cb: (value: string | null) => unknown): this;
 }
 
 /**


### PR DESCRIPTION
While working on a plugin, I noticed that the callback to `SecretComponent#onChange` can emit `null`. This happens if the user de-selects a secret from the secret-management modal that the component triggers

<img width="412" height="128" alt="CleanShot 2026-05-02 at 09 45 28@2x" src="https://github.com/user-attachments/assets/ee6bedc5-6a85-405c-96c6-623dc7355da7" />

Having this accurately reflected is helpful for plugin developers, so they can appropriately handle the values emitted by this component!